### PR TITLE
[Feature] Add partial masking feature

### DIFF
--- a/JsonMasking.Tests/JsonMasking.Tests.csproj
+++ b/JsonMasking.Tests/JsonMasking.Tests.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\JsonMasking\JsonMasking.csproj" />
   </ItemGroup>
-
 </Project>

--- a/JsonMasking.Tests/JsonMaskingTests.cs
+++ b/JsonMasking.Tests/JsonMaskingTests.cs
@@ -200,7 +200,7 @@ namespace JsonMasking.Tests
                 json.MaskFields(blacklist, mask));
 
             // assert
-            Assert.Equal("Value cannot be null.\nParameter name: blacklist", ex.Message.Replace("\r\n","\n"));
+            Assert.Equal("Value cannot be null. (Parameter 'blacklist')", ex.Message.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -216,7 +216,7 @@ namespace JsonMasking.Tests
                 json.MaskFields(blacklist, mask));
 
             // assert
-            Assert.Equal("Value cannot be null.\nParameter name: json", ex.Message.Replace("\r\n", "\n"));
+            Assert.Equal("Value cannot be null. (Parameter 'json')", ex.Message.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -232,7 +232,7 @@ namespace JsonMasking.Tests
                 json.MaskFields(blacklist, mask));
 
             // assert
-            Assert.Equal("Value cannot be null.\nParameter name: json", ex.Message.Replace("\r\n", "\n"));
+            Assert.Equal("Value cannot be null. (Parameter 'json')", ex.Message.Replace("\r\n", "\n"));
         }
 
         [Fact]

--- a/JsonMasking.Tests/JsonMaskingTests.cs
+++ b/JsonMasking.Tests/JsonMaskingTests.cs
@@ -1,8 +1,8 @@
-using Newtonsoft.Json;
-using JsonMasking;
-using System;
-using Xunit;
 using JsonMasking.Tests.Mocks;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using Xunit;
 
 namespace JsonMasking.Tests
 {
@@ -19,14 +19,14 @@ namespace JsonMasking.Tests
                 Password = "somepass#here"
             };
             var json = JsonConvert.SerializeObject(obj, Formatting.Indented);
-            string[] blacklist = {};
+            string[] blacklist = { };
             var mask = "*******";
 
             // act
             var result = json.MaskFields(blacklist, mask);
 
             // assert
-            Assert.Equal("{\n  \"Test\": \"1\",\n  \"Password\": \"somepass#here\"\n}", result.Replace("\r\n","\n"));
+            Assert.Equal("{\n  \"Test\": \"1\",\n  \"Password\": \"somepass#here\"\n}", result.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace JsonMasking.Tests
             var result = json.MaskFields(blacklist, mask);
 
             // assert
-            Assert.Equal("{\n  \"Test\": \"1\",\n  \"OtherField\": \"somepass#here\"\n}", result.Replace("\r\n","\n"));
+            Assert.Equal("{\n  \"Test\": \"1\",\n  \"OtherField\": \"somepass#here\"\n}", result.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace JsonMasking.Tests
             var result = json.MaskFields(blacklist, mask);
 
             // assert
-            Assert.Equal("{\n  \"Test\": \"1\",\n  \"Password\": \"----\"\n}", result.Replace("\r\n","\n"));
+            Assert.Equal("{\n  \"Test\": \"1\",\n  \"Password\": \"----\"\n}", result.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace JsonMasking.Tests
             var result = json.MaskFields(blacklist, mask);
 
             // assert
-            Assert.Equal("{\n  \"Test\": 1,\n  \"Password\": \"*******\"\n}", result.Replace("\r\n","\n"));
+            Assert.Equal("{\n  \"Test\": 1,\n  \"Password\": \"*******\"\n}", result.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace JsonMasking.Tests
             var result = json.MaskFields(blacklist, mask);
 
             // assert
-            Assert.Equal("{\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"Password\": \"*******\"\n  }\n}", result.Replace("\r\n","\n"));
+            Assert.Equal("{\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"Password\": \"*******\"\n  }\n}", result.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace JsonMasking.Tests
             var result = json.MaskFields(blacklist, mask);
 
             // assert
-            Assert.Equal("{\n  \"Password\": \"*******\",\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"Password\": \"*******\"\n  }\n}", result.Replace("\r\n","\n"));
+            Assert.Equal("{\n  \"Password\": \"*******\",\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"Password\": \"*******\"\n  }\n}", result.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -157,7 +157,7 @@ namespace JsonMasking.Tests
             var result = json.MaskFields(blacklist, mask);
 
             // assert
-            Assert.Equal("{\n  \"Password\": \"*******\",\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"CreditCardNumber\": \"*******\"\n  }\n}", result.Replace("\r\n","\n"));
+            Assert.Equal("{\n  \"Password\": \"*******\",\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"CreditCardNumber\": \"*******\"\n  }\n}", result.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace JsonMasking.Tests
             var result = json.MaskFields(blacklist, mask);
 
             // assert
-            Assert.Equal("{\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"Password\": \"*******\"\n  }\n}", result.Replace("\r\n","\n"));
+            Assert.Equal("{\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"Password\": \"*******\"\n  }\n}", result.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -297,7 +297,7 @@ namespace JsonMasking.Tests
             var result = json.MaskFields(blacklist, mask);
 
             // assert
-            Assert.Equal("{\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"Password\": \"somepass#here\",\n    \"DepthObject\": {\n      \"Test\": \"1\",\n      \"Password\": \"*******\"\n    }\n  },\n  \"DepthObject2\": {\n    \"Test\": \"1\",\n    \"Password\": \"somepass#here\",\n    \"DepthObject\": {\n      \"Test\": \"1\",\n      \"Password\": \"*******\",\n      \"DepthObject\": {\n        \"Test\": \"1\",\n        \"Password\": \"*******\"\n      }\n    }\n  },\n  \"Password\": \"somepass#here\"\n}", result.Replace("\r\n","\n"));
+            Assert.Equal("{\n  \"DepthObject\": {\n    \"Test\": \"1\",\n    \"Password\": \"somepass#here\",\n    \"DepthObject\": {\n      \"Test\": \"1\",\n      \"Password\": \"*******\"\n    }\n  },\n  \"DepthObject2\": {\n    \"Test\": \"1\",\n    \"Password\": \"somepass#here\",\n    \"DepthObject\": {\n      \"Test\": \"1\",\n      \"Password\": \"*******\",\n      \"DepthObject\": {\n        \"Test\": \"1\",\n        \"Password\": \"*******\"\n      }\n    }\n  },\n  \"Password\": \"somepass#here\"\n}", result.Replace("\r\n", "\n"));
         }
 
         [Fact]
@@ -458,6 +458,37 @@ namespace JsonMasking.Tests
             };
             var json = JsonConvert.SerializeObject(obj, Formatting.Indented);
             string[] blacklist = { };
+            var mask = "----";
+
+            // act
+            var result = json.MaskFields(blacklist, mask, blacklistPartialMock);
+
+            // assert
+            Assert.Equal(EXPECTED_VALUE, result.Replace("\r\n", "\n"));
+        }
+
+        [Fact]
+        public static void MaskFields_Should_Mask_Completely_If_Deledate_return_Same_Value()
+        {
+            // arrange
+            const string EXPECTED_VALUE = "{\n  \"Test\": \"1\",\n  \"Card\": {\n    \"Number\": \"----\",\n    \"Password\": \"somepass#here2\"\n  }\n}";
+
+            var blacklistPartialMock = new Dictionary<string, Func<string, string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "*card.number", text => text }
+            };
+
+            var obj = new
+            {
+                Test = "1",
+                Card = new
+                {
+                    Number = "4622943127049865",
+                    Password = "somepass#here2"
+                }
+            };
+            var json = JsonConvert.SerializeObject(obj, Formatting.Indented);
+            string[] blacklist = { "*card.number" };
             var mask = "----";
 
             // act

--- a/JsonMasking.Tests/Mocks/BlacklistPartialMock.cs
+++ b/JsonMasking.Tests/Mocks/BlacklistPartialMock.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace JsonMasking.Tests.Mocks
+{
+    public static class BlacklistPartialMock
+    {
+        private const string CARD_NUMBER_PATTER = @"(\d{4,5})[ -|]?(\d{3,6})[ -|]?(\d{3,5})[ -|]?(\d{3,4})";
+
+        public static Dictionary<string, Func<string, string>> DefaultBlackListPartial = new Dictionary<string, Func<string, string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            {"*card.number", MaskCardNumber }
+        };
+
+        public static string MaskCardNumber(this string text)
+        {
+            if (string.IsNullOrEmpty(text) || !ContainsCardNumber(text))
+                return text;
+
+            return Regex.Replace(
+                text,
+                CARD_NUMBER_PATTER,
+                match => $"{match.Value.Substring(0, 6)}*****{match.Value.Substring(match.Value.Length - 4, 4)}");
+        }
+
+        public static bool ContainsCardNumber(this string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return false;
+
+            return Regex.IsMatch(text, CARD_NUMBER_PATTER);
+        }
+    }
+}

--- a/JsonMasking/JsonMasking.cs
+++ b/JsonMasking/JsonMasking.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -19,8 +18,9 @@ namespace JsonMasking
         /// <param name="json">json to mask properties</param>
         /// <param name="blacklist">insensitive property array</param>
         /// <param name="mask">mask to replace property value</param>
+        /// <param name="blacklistPartial">Optional. Dictionary where the key is the property to be masked and the value is the function to apply to the property</param>
         /// <returns></returns>
-        public static string MaskFields(this string json, string[] blacklist, string mask)
+        public static string MaskFields(this string json, string[] blacklist, string mask, Dictionary<string, Func<string, string>> blacklistPartial = null)
         {
             if (string.IsNullOrWhiteSpace(json) == true)
             {
@@ -37,8 +37,16 @@ namespace JsonMasking
                 return json;
             }
 
-            var jsonObject = (JObject) JsonConvert.DeserializeObject(json);
-            MaskFieldsFromJToken(jsonObject, blacklist, mask);
+            var jsonObject = (JObject)JsonConvert.DeserializeObject(json);
+
+            if (blacklistPartial != null)
+            {
+                MaskFieldsFromJToken(jsonObject, blacklist, mask, blacklistPartial);
+            }
+            else
+            {
+                MaskFieldsFromJToken(jsonObject, blacklist, mask);
+            }
 
             return jsonObject.ToString();
         }
@@ -65,12 +73,11 @@ namespace JsonMasking
                 {
                     var matching = blacklist.Any(item =>
                     {
-                        return 
-                            Regex.IsMatch(prop.Path, WildCardToRegular(item), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                        return IsMatch(prop.Path, item);
                     });
 
                     if (matching)
-                    {    
+                    {
                         removeList.Add(jtoken);
                     }
                 }
@@ -85,6 +92,80 @@ namespace JsonMasking
                 var prop = (JProperty)el;
                 prop.Value = mask;
             }
+        }
+
+        /// <summary>
+        /// Mask fields completely or partially from JToken
+        /// </summary>
+        /// <param name="token"></param>
+        /// <param name="blacklist"></param>
+        /// <param name="mask"></param>
+        /// <param name="blacklistPartial"></param>
+        /// <param name="namespaceItems"></param>
+        private static void MaskFieldsFromJToken(JToken token, string[] blacklist, string mask, Dictionary<string, Func<string, string>> blacklistPartial)
+        {
+            JContainer container = token as JContainer;
+            if (container == null)
+            {
+                return; // abort recursive
+            }
+
+            List<JToken> removeList = new List<JToken>();
+            foreach (JToken jtoken in container.Children())
+            {
+                if (jtoken is JProperty prop)
+                {
+                    var matching = blacklist.Any(item =>
+                    {
+                        return IsMatch(prop.Path, item);
+                    });
+
+                    if (matching)
+                    {
+                        removeList.Add(jtoken);
+                    }
+                }
+
+                // call recursive 
+                MaskFieldsFromJToken(jtoken, blacklist, mask, blacklistPartial);
+            }
+
+            foreach (JToken el in removeList)
+            {
+                var prop = (JProperty)el;
+
+                if (blacklistPartial.TryGetValue(blacklistPartial.GetKey(prop.Path), out var maskFunc))
+                {
+                    var value = prop.Value.ToString();
+                    var valueMasked = maskFunc(value);
+                    prop.Value = (valueMasked != value && valueMasked.Contains("*")) ? valueMasked : mask;
+                }
+                else
+                {
+                    prop.Value = mask;
+                }
+            }
+        }
+
+        private static string GetKey(this Dictionary<string, Func<string, string>> blacklistPartial, string key)
+        {
+            if (String.IsNullOrEmpty(key))
+            {
+                return key;
+            }
+
+            var result = blacklistPartial.Keys.FirstOrDefault(dictionaryKey =>
+            {
+                return IsMatch(key, dictionaryKey);
+            });
+
+            return result ?? key;
+        }
+
+        private static bool IsMatch(string key, string value)
+        {
+            return Regex.IsMatch(key, WildCardToRegular(value), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
         }
 
         private static string WildCardToRegular(string value)

--- a/JsonMasking/JsonMasking.cs
+++ b/JsonMasking/JsonMasking.cs
@@ -138,7 +138,7 @@ namespace JsonMasking
                 {
                     var value = prop.Value.ToString();
                     var valueMasked = maskFunc(value);
-                    prop.Value = (valueMasked != value && valueMasked.Contains("*")) ? valueMasked : mask;
+                    prop.Value = (valueMasked != value) ? valueMasked : mask;
                 }
                 else
                 {
@@ -149,11 +149,6 @@ namespace JsonMasking
 
         private static string GetKey(this Dictionary<string, Func<string, string>> blacklistPartial, string key)
         {
-            if (String.IsNullOrEmpty(key))
-            {
-                return key;
-            }
-
             var result = blacklistPartial.Keys.FirstOrDefault(dictionaryKey =>
             {
                 return IsMatch(key, dictionaryKey);
@@ -165,7 +160,6 @@ namespace JsonMasking
         private static bool IsMatch(string key, string value)
         {
             return Regex.IsMatch(key, WildCardToRegular(value), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-
         }
 
         private static string WildCardToRegular(string value)

--- a/JsonMasking/JsonMasking.csproj
+++ b/JsonMasking/JsonMasking.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
![image](https://github.com/ThiagoBarradas/jsonmasking/assets/92134670/5d0f1911-3d1e-416d-a404-a9c81dea6546)

### Status

IN REVIEW

### Whats?

Add the option for a new blacklist where some properties do not need to be fully masked anymore. New rules can be applied to them for partial masking.

### Why?

We need a way to display the card BINs, and the option to apply a custom partial mask would solve this problem.

### How?

Add a new parameter, which is a dictionary where the key is the property to be masked and the value is a function that applies a specific masking rule to that property.

### Definition of Done:
- [x] Increases API documentation
- [ ] Implements integration tests
- [x] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [x] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
