### PR TITLE
Feature/add partial masking feature - add try-catch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: microsoft/dotnet:2.2-sdk
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
     steps:
       - checkout
       - run:
@@ -26,7 +26,7 @@ jobs:
   unit_tests:
     working_directory: /
     docker:
-      - image: microsoft/dotnet:2.2-sdk
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
     steps:
       - attach_workspace:
           at: /

--- a/JsonMasking.Tests/Mocks/BlacklistPartialMock.cs
+++ b/JsonMasking.Tests/Mocks/BlacklistPartialMock.cs
@@ -6,7 +6,9 @@ namespace JsonMasking.Tests.Mocks
 {
     public static class BlacklistPartialMock
     {
-        private const string CARD_NUMBER_PATTER = @"(\d{4,5})[ -|]?(\d{3,6})[ -|]?(\d{3,5})[ -|]?(\d{3,4})";
+        private const string CARD_NUMBER_PATTERN = @"(\d{4,5})[ -|]?(\d{3,6})[ -|]?(\d{3,5})[ -|]?(\d{3,4})";
+
+        private const string EMPTY_SPACE_PATTERN = @"\s+";
 
         public static Dictionary<string, Func<string, string>> DefaultBlackListPartial = new Dictionary<string, Func<string, string>>(StringComparer.OrdinalIgnoreCase)
         {
@@ -15,13 +17,23 @@ namespace JsonMasking.Tests.Mocks
 
         public static string MaskCardNumber(this string text)
         {
-            if (string.IsNullOrEmpty(text) || !ContainsCardNumber(text))
-                return text;
+            const int MINIMAL_LENGTH = 10;
 
-            return Regex.Replace(
-                text,
-                CARD_NUMBER_PATTER,
-                match => $"{match.Value.Substring(0, 6)}*****{match.Value.Substring(match.Value.Length - 4, 4)}");
+            text = Regex.Replace(text, EMPTY_SPACE_PATTERN, "");
+
+            if (string.IsNullOrEmpty(text) || text.Length < MINIMAL_LENGTH || !ContainsCardNumber(text))
+            {
+                return text;
+            }
+
+            var firstSix = text[..6];
+            var lastFour = text[^4..];
+            if (firstSix.Length == 6 && lastFour.Length == 4)
+            {
+                return $"{firstSix}*****{lastFour}";
+            }
+
+            return text;
         }
 
         public static bool ContainsCardNumber(this string text)
@@ -29,7 +41,7 @@ namespace JsonMasking.Tests.Mocks
             if (string.IsNullOrEmpty(text))
                 return false;
 
-            return Regex.IsMatch(text, CARD_NUMBER_PATTER);
+            return Regex.IsMatch(text, CARD_NUMBER_PATTERN);
         }
     }
 }

--- a/JsonMasking/JsonMasking.cs
+++ b/JsonMasking/JsonMasking.cs
@@ -137,8 +137,16 @@ namespace JsonMasking
                 if (blacklistPartial.TryGetValue(blacklistPartial.GetKey(prop.Path), out var maskFunc))
                 {
                     var value = prop.Value.ToString();
-                    var valueMasked = maskFunc(value);
-                    prop.Value = (valueMasked != value) ? valueMasked : mask;
+                    try
+                    {
+                        var valueMasked = maskFunc(value);
+                        prop.Value = (valueMasked != value) ? valueMasked : mask;
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidOperationException(
+                            $"An error occurred while executing the function in the dictionary value. {ex.Message}");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
![image](https://github.com/ThiagoBarradas/jsonmasking/assets/92134670/02a45970-64a5-4424-9dc5-193865fd94d1)

Status
READY

What?
Added a try-catch block to handle cases where an invalid function is passed in the dictionary.

Why?
To properly handle potential errors.

How?
Correctly handle any issues that occur in the function passed as the value in the dictionary.

## Evidencia

![image](https://github.com/ThiagoBarradas/jsonmasking/assets/92134670/e8071d1d-443c-41c4-bc11-d4c5840e8914)
![image](https://github.com/ThiagoBarradas/jsonmasking/assets/92134670/6b648636-c976-4cc2-abf1-29b9aed27b96)



### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [X] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
