### PR TITLE
[Feature] Add validation on dictionary value

### DIFF
--- a/JsonMasking.Tests/JsonMaskingTests.cs
+++ b/JsonMasking.Tests/JsonMaskingTests.cs
@@ -527,7 +527,8 @@ namespace JsonMasking.Tests
             // assert
             Assert.Equal(EXPECTED_VALUE, result.Replace("\r\n", "\n"));
         }
-      
+
+        [Fact]
         public static void MaskFields_Should_Mask_With_Wildcard_ForJsonArray()
         {
             // arrange
@@ -636,6 +637,37 @@ namespace JsonMasking.Tests
 
             // assert
             Assert.Equal(numberMasked, expected);
+        }
+
+        [Fact]
+        public static void MaskFields_Should_Mask_Completely_If_Delegate_Is_Null()
+        {
+            // arrange
+            const string EXPECTED_VALUE = "{\n  \"Test\": \"1\",\n  \"Card\": {\n    \"Number\": \"----\",\n    \"Password\": \"somepass#here2\"\n  }\n}";
+
+            var blacklistPartialMock = new Dictionary<string, Func<string, string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "*card.number", null }
+            };
+
+            var obj = new
+            {
+                Test = "1",
+                Card = new
+                {
+                    Number = "4622943127049865",
+                    Password = "somepass#here2"
+                }
+            };
+            var json = JsonConvert.SerializeObject(obj, Formatting.Indented);
+            string[] blacklist = { "*card.number" };
+            var mask = "----";
+
+            // act
+            var result = json.MaskFields(blacklist, mask, blacklistPartialMock);
+
+            // assert
+            Assert.Equal(EXPECTED_VALUE, result.Replace("\r\n", "\n"));
         }
     }
 }

--- a/JsonMasking/JsonMasking.cs
+++ b/JsonMasking/JsonMasking.cs
@@ -151,7 +151,7 @@ namespace JsonMasking
                     var value = prop.Value.ToString();
                     try
                     {
-                        var valueMasked = maskFunc(value);
+                        var valueMasked = (maskFunc != null) ? maskFunc(value) : mask;
                         prop.Value = (valueMasked != value) ? valueMasked : mask;
                     }
                     catch (Exception ex)


### PR DESCRIPTION
![shame-on-you-sad](https://github.com/ThiagoBarradas/jsonmasking/assets/92134670/a0c5c0a9-e034-42a7-bc7a-1ee7cd939f6f)

### Status

READY

### Whats?

Add validation to ensure that the value is not null. If it is, the field should be completely masked.

### Why?

Currently, if null is passed as the value, JsonMasking is aborted and AspNet.Serilog returns the object unchanged, exposing all data. This results in logs containing open card data and other sensitive information.

### How?

This can be resolved by adding a simple validation. If the delegate is null, it should completely mask the data instead of aborting the JsonMasking.

### Attachments (if appropriate)

![image](https://github.com/ThiagoBarradas/jsonmasking/assets/92134670/655cf950-b7f3-4d29-a4b2-d468f909f175)

![image](https://github.com/ThiagoBarradas/jsonmasking/assets/92134670/30ed0a3f-68d8-4ac8-887c-eb8948ed54ed)


### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [X] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
